### PR TITLE
Handle zero elevation correctly in elevation profile

### DIFF
--- a/backend/elevation_utils.py
+++ b/backend/elevation_utils.py
@@ -145,8 +145,9 @@ def get_route_elevation_profile(G, path: List, sample_rate: int = 10) -> dict:
     return {
         "elevation_gain": round(elevation_gain, 1),
         "elevation_loss": round(elevation_loss, 1),
-        "max_elevation": round(max_elevation, 1) if max_elevation else None,
-        "min_elevation": round(min_elevation, 1) if min_elevation else None,
+        # Handle 0-meter elevations correctly by explicitly checking for None
+        "max_elevation": round(max_elevation, 1) if max_elevation is not None else None,
+        "min_elevation": round(min_elevation, 1) if min_elevation is not None else None,
         "elevation_profile": elevations,
         "smoothed_elevation_profile": [round(e, 1) for e in smoothed_elevations] if smoothed_elevations else []
     }

--- a/backend/test_elevation_profile.py
+++ b/backend/test_elevation_profile.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+import networkx as nx
+
+# Add backend directory to sys.path
+sys.path.append(str(Path(__file__).parent))
+import elevation_utils
+
+
+def test_get_route_elevation_profile_handles_zero_elevation(monkeypatch):
+    G = nx.Graph()
+    G.add_node(1, x=0.0, y=0.0)
+    G.add_node(2, x=1.0, y=1.0)
+
+    def fake_get_elevation_data(coords):
+        return [0.0, 0.0]
+
+    monkeypatch.setattr(elevation_utils, "get_elevation_data", fake_get_elevation_data)
+
+    profile = elevation_utils.get_route_elevation_profile(G, [1, 2], sample_rate=1)
+
+    assert profile["max_elevation"] == 0.0
+    assert profile["min_elevation"] == 0.0


### PR DESCRIPTION
## Summary
- fix `get_route_elevation_profile` so routes at sea level keep 0 m min/max elevations
- add regression test for zero-elevation routes

## Testing
- `pytest backend/test_cache.py backend/test_elevation_profile.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68940445f894832e91858cd0f1a86ea7